### PR TITLE
Bugs default value and htm ltabs

### DIFF
--- a/sql/csp_lip_createfield.sql
+++ b/sql/csp_lip_createfield.sql
@@ -3,12 +3,12 @@ IF EXISTS (SELECT name FROM sysobjects WHERE name = 'csp_lip_createfield' AND UP
 GO
 -- Written by: Fredrik Eriksson, Jonny Springare
 -- Created: 2015-04-16
--- Last updated: 2017-02-09
+-- Last updated: 2017-03-23
 CREATE PROCEDURE [dbo].[csp_lip_createfield]
 	@@tablename NVARCHAR(64)
 	, @@fieldname NVARCHAR(64)
 	, @@fieldtype NVARCHAR(64)
-	, @@defaultvalue NVARCHAR(64) = NULL
+	, @@defaultvalue NVARCHAR(125) = NULL --defaultvalue in lsp_addfield takes 128 chars, but only 125 can be set
 	, @@length INT = NULL
 	, @@isnullable INT = 0
 	, @@errorMessage NVARCHAR(MAX) OUTPUT

--- a/sql/csp_lip_setfieldattributes.sql
+++ b/sql/csp_lip_setfieldattributes.sql
@@ -3,7 +3,7 @@ IF EXISTS (SELECT name FROM sysobjects WHERE name = 'csp_lip_setfieldattributes'
 GO
 -- Written by: Jonny Springare
 -- Created: 2017-02-09
--- Last updated: 2017-02-09
+-- Last updated: 2017-03-23
 CREATE PROCEDURE [dbo].[csp_lip_setfieldattributes]	
 	@@idfield INT
 	, @@idcategory INT
@@ -660,7 +660,7 @@ BEGIN
 		END								
 	END
 	
-	IF @@fieldtype IN (N'time', N'option', N'decimal', N'document',N'integer',N'file')
+	IF @@fieldtype IN (N'time', N'option', N'decimal', N'document', N'integer', N'file', N'html')
 	BEGIN
 		--Set type for timefield or optionlist
 		EXEC @return_value = [dbo].[lsp_setfieldattributevalue] @@idfield = @@idfield, @@name = N'type', @@valueint = @@type

--- a/vba/lip.bas
+++ b/vba/lip.bas
@@ -1,6 +1,7 @@
 Attribute VB_Name = "lip"
 Option Explicit
 
+'Last updated: 2017-03-23
 'Lundalogik Package Store, DO NOT CHANGE, used to download system files for LIP
 'Please add your own stores in packages.json
 Private Const BaseURL As String = "http://api.lime-bootstrap.com"
@@ -1817,6 +1818,8 @@ On Error GoTo ErrorHandler
     Application.Shell sLogfile
     
     Call AskIfInstallPackageBuilder
+    
+    Application.MousePointer = 0
     
     Exit Sub
 ErrorHandler:


### PR DESCRIPTION
Fixed bugs:
* HTML-tabs were installed as HTML-fields
* Default values longer than 64 chars wasn't allowed, now up to 125 chars are allowed
* Mousepointer weren't set back to normal after LIP were installed if you chose not to install PackageBuilder