### PR TITLE
Errors when creating options for decimal or textfields

### DIFF
--- a/sql/csp_lip_setfieldattributes.sql
+++ b/sql/csp_lip_setfieldattributes.sql
@@ -3,7 +3,7 @@ IF EXISTS (SELECT name FROM sysobjects WHERE name = 'csp_lip_setfieldattributes'
 GO
 -- Written by: Jonny Springare
 -- Created: 2017-02-09
--- Last updated: 2017-03-23
+-- Last updated: 2017-05-04
 CREATE PROCEDURE [dbo].[csp_lip_setfieldattributes]	
 	@@idfield INT
 	, @@idcategory INT

--- a/sql/csp_lip_setfieldattributes.sql
+++ b/sql/csp_lip_setfieldattributes.sql
@@ -69,7 +69,7 @@ BEGIN
 	--Set idcategory for textfield or decimal-field, since this isn't done by lsp_addfield (only setfields and optionfields)
 	IF @@fieldtype = N'string' OR @@fieldtype = N'decimal'
 	BEGIN
-		SET @@idcategory = NULL
+		SET @@idcategory = -1
 		EXEC @return_value =  lsp_setfieldattributevalue @@idfield = @@idfield, 
 										 @@name = N'idcategory',
 										 @@valueint = @@idcategory OUTPUT


### PR DESCRIPTION
Test:
* Create four different fields: one textfield without options, one textfield WITH options, one decimalfield without options, one decimalfield WITH options
* Create a package with these fields
* Install the package to another database
* Verify that all four fields have been created correctly